### PR TITLE
array and callable typehint for aop class inheritance 

### DIFF
--- a/src/CodeGenMethod.php
+++ b/src/CodeGenMethod.php
@@ -98,6 +98,12 @@ final class CodeGenMethod
         if ($typeHint) {
             $paramStmt->setTypeHint($typeHint->name);
         }
+        if ($param->isArray()) {
+            $paramStmt->setTypeHint('array');
+        }
+        if ($param->isCallable()) {
+            $paramStmt->setTypeHint('callable');
+        }
         if ($param->isDefaultValueAvailable()) {
             $paramStmt->setDefault($param->getDefaultValue());
         }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -188,4 +188,12 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $annotations = (new AnnotationReader)->getMethodAnnotations(new \ReflectionMethod($class, 'getDouble'));
         $this->assertSame(3, count($annotations));
     }
+
+    public function testArrayTypehintedAndCallable()
+    {
+        $class = $this->compiler->compile(FakeArrayTypehinted::class, $this->bind);
+        $parent = (new \ReflectionClass($class))->getParentClass()->getName();
+        $expected = 'Ray\Aop\FakeArrayTypehinted';
+        $this->assertSame($expected, $parent);
+    }
 }

--- a/tests/Fake/FakeArrayInterface.php
+++ b/tests/Fake/FakeArrayInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ray\Aop;
+
+interface FakeArrayInterface
+{
+    public function invoke(array $array, callable $callable);
+}
+

--- a/tests/Fake/FakeArrayTypehinted.php
+++ b/tests/Fake/FakeArrayTypehinted.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Aop;
+
+class FakeArrayTypehinted implements FakeArrayInterface
+{
+    public function invoke(array $array, callable $callable)
+    {
+    }
+}
+


### PR DESCRIPTION
It caused error `array` or `callable` parameter type hint are not copied into generated aop class. 