### PR TITLE
Interceptor invoke priority

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,12 @@
-Aspect Oriented Framework for PHP
-=================================
+# Ray.Aop
+
+## Aspect Oriented Framework for PHP
 
 [![Latest Stable Version](https://poser.pugx.org/ray/aop/v/stable.png)](https://packagist.org/packages/ray/aop)
-[![Build Status](https://secure.travis-ci.org/koriym/Ray.Aop.png)](http://travis-ci.org/koriym/Ray.Aop)
+[![Latest Unstable Version](http://img.shields.io/badge/unstable-~2.0%40dev-green.svg)](https://packagist.org/packages/ray/aop)
+[![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/koriym/Ray.Aop/badges/quality-score.png?develop-2)](https://scrutinizer-ci.com/g/koriym/Ray.Aop/)
+[![Code Coverage](https://scrutinizer-ci.com/g/koriym/Ray.Aop/badges/coverage.png?s=5604fdfae48a5a31242d3e46018515e2f30083d7)](https://scrutinizer-ci.com/g/koriym/Ray.Aop/)
+[![Build Status](https://secure.travis-ci.org/koriym/Ray.Aop.png?branch=develop-2)](http://travis-ci.org/koriym/Ray.Aop)
 
 [[English]](https://github.com/koriym/Ray.Aop/blob/develop/README.md)
 
@@ -16,7 +20,7 @@ Aspect Oriented Framework for PHP
 Example: Forbidding method calls on weekends
 --------------------------------------------
 
-メソッドインターセプターがRay.Aopでどのように機能するかを明らかにするために、終末にはピザの注文を禁止するようにしてみましょう。デリバリーは平日だけ受け付ける事にして、ピザの注文を週末には受け付けないようにします！この例はAOPで認証を使用するときにのパターンと構造的に似ています。
+メソッドインターセプターがRay.Aopでどのように機能するかを明らかにするために、週末にはピザの注文を禁止するようにしてみましょう。デリバリーは平日だけ受け付ける事にして、ピザの注文を週末には受け付けないようにします！この例はAOPで認証を使用するときにのパターンと構造的に似ています。
 
 週末だけにするための[アノテーション](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html)を定義します。
 
@@ -160,6 +164,22 @@ $pointcut = new Pointcut(
 );
 $bind = new Bind(RealBillingService::class, [$pointcut]);
 $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
+```
+
+Priority
+--------
+インターセプターの実行順は以下のルールで決定されます。
+
+ * 基本的にはバインドした順に実行されます。
+ * `PriorityPointcut`で定義したものが最も優先されます。
+ * アノテーションでメソッドマッチするものは`PriorityPointcut`の次に優先されます。その時アノテートされた順で優先されます。
+
+```php
+/**
+ * @Auth    // 1st
+ * @Cache   // 2nd
+ * @Log     // 3rd
+ */
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ $pointcut = new Pointcut(
 $bind = new Bind(RealBillingService::class, [$pointcut]);
 $billing = (new Compiler($tmpDir))->newInstance(RealBillingService::class, [], $bind);
 ```
+Priority
+--------
+
+The order of interceptor invocation are determined by following rules.
+
+ * Basically, it will be invoked in bind order.
+ * `PriorityPointcut` has most priority.
+ * Annotation method match is followed by `PriorityPointcut`. Invoked in annotation order as follows.
+
+```php
+/**
+ * @Auth    // 1st
+ * @Cache   // 2nd
+ * @Log     // 3rd
+ */
+```
 
 Limitations
 -----------

--- a/docs/demo/bootstrap.php
+++ b/docs/demo/bootstrap.php
@@ -1,7 +1,11 @@
 <?php
 
-$loader = require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
-/** @var $loader \Composer\Autoload\ClassLoader */
-$loader->addPsr4('Ray\Aop\Demo\\', __DIR__ . '/src/');
+use Doctrine\Common\Annotations\AnnotationRegistry;
 
+/** @var $loader \Composer\Autoload\ClassLoader */
+$loader = require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
+$loader->addPsr4('Ray\Aop\Demo\\', __DIR__ . '/src/');
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+
+// tmp dir
 $_ENV['TMP_DIR'] = __DIR__ . '/tmp';

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -57,11 +57,19 @@ final class Bind implements BindInterface
     /**
      * @param ReflectionClass  $class
      * @param ReflectionMethod $method
-     * @param array            $pointcuts
+     * @param Pointcut[]       $pointcuts
      */
     private function annotatedMethodMatch(\ReflectionClass $class, \ReflectionMethod $method, array &$pointcuts)
     {
         $annotations = $this->reader->getMethodAnnotations($method);
+        // priority bind
+        foreach ($pointcuts as $key => $pointcut) {
+            if ($pointcut instanceof PriorityPointcut) {
+                $this->annotatedMethodMatchBind($class, $method, $pointcut);
+                unset($pointcuts[$key]);
+            }
+        }
+        // method bind in annotation order
         foreach ($annotations as $annotation) {
             $annotationIndex = get_class($annotation);
             if (isset($pointcuts[$annotationIndex])) {
@@ -69,6 +77,7 @@ final class Bind implements BindInterface
                 unset($pointcuts[$annotationIndex]);
             }
         }
+        // default binding
         foreach ($pointcuts as $pointcut) {
             $this->annotatedMethodMatchBind($class, $method, $pointcut);
         }

--- a/src/Pointcut.php
+++ b/src/Pointcut.php
@@ -6,7 +6,7 @@
  */
 namespace Ray\Aop;
 
-final class Pointcut
+class Pointcut
 {
     /**
      * @var AbstractMatcher

--- a/src/PriorityPointcut.php
+++ b/src/PriorityPointcut.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the Ray.Aop package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Aop;
+
+final class PriorityPointcut extends Pointcut
+{
+}

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -89,4 +89,23 @@ class BindTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertSame($expect, $actual);
     }
+
+    public function testOnionAnnotationAndPriorityPointcut()
+    {
+        $onion1 = new FakeOnionInterceptor1;
+        $onion2 = new FakeOnionInterceptor2;
+        $onion3 = new FakeOnionInterceptor3;
+        $onion4 = new FakeOnionInterceptor4;
+        $pointcut0 = new Pointcut((new Matcher)->any(), (new Matcher)->startsWith('XXX'), [$onion1]);
+        $pointcut1 = new Pointcut((new Matcher)->any(), (new Matcher)->annotatedWith(FakeMarker::class), [$onion1]);
+        $pointcut2 = new Pointcut((new Matcher)->any(), (new Matcher)->annotatedWith(FakeMarker2::class), [$onion2]);
+        $pointcut3 = new Pointcut((new Matcher)->any(), (new Matcher)->annotatedWith(FakeMarker3::class), [$onion3]);
+        $pointcut4 = new PriorityPointcut((new Matcher)->annotatedWith(FakeResource::class), (new Matcher)->any(), [$onion4]);
+        $this->bind->bind(FakeAnnotateClass::class, [$pointcut0, $pointcut1, $pointcut2, $pointcut3, $pointcut4]);
+        $actual = $this->bind->getBindings();
+        $expect = [
+            'getDouble' => [$onion4, $onion3, $onion2, $onion1]
+        ];
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/Fake/FakeOnionInterceptor4.php
+++ b/tests/Fake/FakeOnionInterceptor4.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Aop;
+
+class FakeOnionInterceptor4 implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        return $invocation->proceed();
+    }
+}


### PR DESCRIPTION
The order of interceptor invocation are determined by following rules.

 * Basically, it will be invoked in bind order.
 * `PriorityPointcut` has most priority.
 * Annotation method match is followed by `PriorityPointcut`. Invoked in annotation order as follows.
